### PR TITLE
Fix builds on windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,10 @@
 var webpack = require('webpack');
 var poststylus = require('poststylus');
+var path = require('path')
 
 module.exports = {
 	devtool: 'source-map',
-	entry: __dirname + '/src',
+	entry: path.resolve(__dirname, 'src'),
 	output: {
 		path: 'public/builds/',
 		filename: 'bundle.js'
@@ -13,7 +14,7 @@ module.exports = {
 			{
 				test: /\.jsx?$/,
 				loader: 'babel',
-				include: __dirname + '/src',
+				include: path.resolve(__dirname, 'src'),
 				query: {
 					presets: ['es2015'],
 					plugins: ['mjsx']
@@ -32,7 +33,7 @@ module.exports = {
 	stylus: {
 		use: [
 			function (stylus) {
-				stylus.import(__dirname + '/src/stylus/variables');
+				stylus.import(path.resolve(__dirname, 'src/stylus/variables'));
 			},
 			poststylus([ 'autoprefixer' ])
 		]


### PR DESCRIPTION
`__dirname` uses `\` for paths on windows, looks like it didn't play nicely when mixing it with `/`